### PR TITLE
Fix JSON syntax in task.json

### DIFF
--- a/Tasks/TerraformEnterprise/task.json
+++ b/Tasks/TerraformEnterprise/task.json
@@ -63,7 +63,7 @@
                "update": "Update",
                "delete": "Delete"
             }
-        },
+        }
     ],
     "execution": {
         "Node": {


### PR DESCRIPTION
Quick fix for JSON syntax. Otherwise, the task upload fails with the following:

```
tfx build tasks upload --task-path ./azure-pipelines-extension-terraform/Tasks/TerraformEnterpriseTFS Cross Platform Command Line Interface v0.7.11
Copyright Microsoft Corporation

error: Error: Invalid task json: SyntaxError: /home/vagrant/azure-pipelines-extension-terraform/Tasks/TerraformEnterprise/task.json: Unexpected token ] in JSON at position 2225
```